### PR TITLE
Removed 300K MacRog POPE data, because exp data is at 310K, for which…

### DIFF
--- a/manuscriptPGPEsuppl.tex
+++ b/manuscriptPGPEsuppl.tex
@@ -422,7 +422,7 @@ For united atom simulations, we first constructed trajectories including hydroge
       POPE  & Slipids / {\AA}qvist \cite{jambeck12b,aqvist90}  & 0.11 & 500 & 25000 & 50  &  310  & 500 & 100 & \cite{POPEslipids150mMNaCl} \\
       \hline
       DPPE  & GROMOS-CKP    \cite{??}      &0    & 128	& 3655  &0    & 342  & 2$\times$500 & 2$\times$400 & \cite{gromosCKPdppe} \\
-      POPE  & GROMOS-CKP    \cite{??}      &0    & 128	& 3552  &0    & 313  & 2$\times$500 & 2$\times$400 & \cite{gromosCKPpope} \\
+%      POPE  & GROMOS-CKP    \cite{??}      &0    & 128	& 3552  &0    & 313  & 2$\times$500 & 2$\times$400 & \cite{gromosCKPpope} \\
       POPE  & GROMOS-CKP    \cite{??}      &0    & 500	& 25000 &0    & 310  & 500 & 100 & \cite{gromosCKPpopeT310} \\
       POPE  & GROMOS-CKP    \cite{??}      &0.11 & 500	& 25000 &50   & 310  & 500 & 100 & \cite{gromosCKPpopeT310150mMNaCl} \\
 %      DOPE  & GROMOS-CKP    \cite{??}      &0    & 128	& 4789  &0    & 271  & 2$\times$500 & 2$\times$400 & \cite{gromosCKPdope} \\
@@ -677,7 +677,7 @@ no ion \todo{Simulation details by Fuchs et al.}
 
 \subsection{GROMOS-CKP and GROMOS-CKPM}
 
-\noindent {\it POPE} Data is available at \cite{gromosCKPpope}. \todo{Simulation details by  T. Piggot.}
+\noindent {\it POPE} Data is available at \cite{gromosCKPpopeT310}. \todo{Simulation details by  A. Peon.}
 
 %\noindent {\it DOPE} Data is available at \cite{gromosCKPdope}. \todo{Simulation details by  T. Piggot.}
 

--- a/manuscriptPGPEsuppl.tex
+++ b/manuscriptPGPEsuppl.tex
@@ -433,7 +433,7 @@ For united atom simulations, we first constructed trajectories including hydroge
       POPE  & OPLS-UA \cite{??}            &0    & 128	& 3328     &0    & 303  & 2$\times$200 & 2$\times$100 & \cite{OPLSuaPOPEfiles} \\
       \hline
       POPE  & OPLS-MacRog \cite{rog16}     &0    & 144	& 5760     &0    & 310  & 500 & 350 & \cite{MacRogPOPEfiles} \\
-      POPE  & OPLS-MacRog \cite{rog16}     &0    & 128	& 5120     &0    & 300  & 500 & 300 & \cite{MacRogPOPEfilesT300K} \\
+%      POPE  & OPLS-MacRog \cite{rog16}     &0    & 128	& 5120     &0    & 300  & 500 & 300 & \cite{MacRogPOPEfilesT300K} \\
       \hline
       POPE  & Berger-Vries \cite{??}       &0    & 128	& 3552  &0    & 303  & 2$\times$200 & 2$\times$100 & \cite{bergerPOPEfiles}  \\
       POPE  & Berger-largeH \cite{??}      &0    & 128	& 3552  &0    & 303  & 2$\times$200 & 2$\times$100 & \cite{berger2POPEfiles}  \\
@@ -689,7 +689,7 @@ no ion \todo{Simulation details by Fuchs et al.}
 
 \subsection{OPLS-MacRog}
 
-\noindent {\it POPE} \todo{Simulation details by M. Javanainen and P. Fuchs.}
+\noindent {\it POPE} \todo{Simulation details by M. Javanainen} % and P. Fuchs.}
 
 \noindent {\it POPC:POPE mixtures} \todo{Simulation details by P. Fuchs.}
 


### PR DESCRIPTION
… there is another data set.